### PR TITLE
Fix case statement in main function

### DIFF
--- a/bin/urlgate
+++ b/bin/urlgate
@@ -138,14 +138,12 @@ while getopts ":f:c:lg:se:r:h" OPT ; do
             ((TASK++))
             ((EMPTY++))
             ;;
-            ;;
         l )
             _LIST_=true
             ((SHOW++))
             ;;
         g )
             _GREP_="$OPTARG"
-            ;;
             ;;
         s )
             _SELECT_=true


### PR DESCRIPTION
Remove extra closing semicolons from case statements with main class